### PR TITLE
fix: Specify database name explicitly for Beanie initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,8 +72,7 @@ async def app_init():
         # logger.info("Successfully pinged MongoDB server.")
 
         await init_beanie(
-            database=client.get_default_database(), # Use get_default_database() if db name is in MONGO_URL
-            # Or client["rsvp_app"] if you want to hardcode db name here and it's not in MONGO_URL
+            database=client["rsvp_app"], # Explicitly specify the database name
             document_models=[ReadingSession, RsvpSession, User, QuizAttempt]
         )
         logger.info("Beanie initialized successfully with MongoDB.")


### PR DESCRIPTION
Reverts the use of `client.get_default_database()` back to `client["rsvp_app"]` in `app/main.py` for `init_beanie`.

This is necessary because the MONGO_URL being used does not specify a default database name, which caused a `pymongo.errors.ConfigurationError`. Using the explicit database name "rsvp_app" resolves this startup issue. The SSL fix using `certifi` remains in place.