### PR TITLE
fix: Add tlsAllowInvalidCertificates=True for MongoDB connection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,8 @@ async def app_init():
     try:
         client = AsyncIOMotorClient(
             mongo_url,
-            tlsCAFile=certifi.where() # Use certifi's CA bundle
+            tlsCAFile=certifi.where(), # Use certifi's CA bundle
+            tlsAllowInvalidCertificates=True # Add this line
         )
         # Optional: Verify connection with a simple command, though Beanie's init will do this too
         # await client.admin.command('ping')


### PR DESCRIPTION
Modifies `app/main.py` to include `tlsAllowInvalidCertificates=True` in the `AsyncIOMotorClient` options.

This change is intended for local development troubleshooting to bypass SSL certificate validation issues if other methods (like certifi or system SSL updates) have not resolved connection problems.

This setting is NOT recommended for production environments due to security implications of not fully validating the server's SSL certificate.