### PR TITLE
fix: Attempt to disable TLS for MongoDB connection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -65,8 +65,7 @@ async def app_init():
     try:
         client = AsyncIOMotorClient(
             mongo_url,
-            tlsCAFile=certifi.where(), # Use certifi's CA bundle
-            tlsAllowInvalidCertificates=True # Add this line
+            tls=False # Attempt to disable TLS
         )
         # Optional: Verify connection with a simple command, though Beanie's init will do this too
         # await client.admin.command('ping')


### PR DESCRIPTION
Modifies `app/main.py` to set `tls=False` in the `AsyncIOMotorClient` options and removes previous TLS-specific settings (`tlsCAFile`, `tlsAllowInvalidCertificates`).

This is a last-resort troubleshooting step for local development environments experiencing persistent SSL/TLS handshake issues.

This configuration is NOT recommended and will likely NOT work with MongoDB Atlas, which enforces TLS connections. If this fails, it indicates that the connection cannot be established without TLS, and the underlying local environment issue preventing a successful TLS handshake needs to be addressed.