### PR TITLE
Add DB connection helper

### DIFF
--- a/app/db/connection.py
+++ b/app/db/connection.py
@@ -1,0 +1,21 @@
+import os
+from dotenv import load_dotenv
+from motor.motor_asyncio import AsyncIOMotorClient
+from beanie import init_beanie
+
+from app.models.rsvp_session import RsvpSession
+from app.models.user import User
+from app.models.quiz_attempt import QuizAttempt
+
+load_dotenv()
+
+async def connect_to_mongo() -> AsyncIOMotorClient:
+    """Create MongoDB client and initialize Beanie."""
+    mongo_url = os.getenv("MONGO_URL")
+    if not mongo_url:
+        raise ValueError("MONGO_URL environment variable is not set")
+
+    client = AsyncIOMotorClient(mongo_url)
+    db_name = mongo_url.rsplit("/", 1)[-1]
+    await init_beanie(database=client[db_name], document_models=[RsvpSession, User, QuizAttempt])
+    return client

--- a/app/main.py
+++ b/app/main.py
@@ -2,15 +2,12 @@ from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from loguru import logger
 import sys
-from beanie import init_beanie
-from motor.motor_asyncio import AsyncIOMotorClient
 from dotenv import load_dotenv
 import os
 
+from app.db.connection import connect_to_mongo
+
 #from app.models.session import ReadingSession
-from app.models.rsvp_session import RsvpSession
-from app.models.user import User
-from app.models.quiz_attempt import QuizAttempt
 from app.api.routes import router
 from app.api import rsvp_routes, auth_routes, quiz_routes, stats_routes, assistant_routes
 
@@ -59,8 +56,7 @@ async def http_exception_handler(request: Request, exc: HTTPException):
 # Inicializar MongoDB con Beanie
 @app.on_event("startup")
 async def app_init():
-    client = AsyncIOMotorClient(mongo_url)
-    await init_beanie(database=client["rsvp_app"], document_models=[ RsvpSession, User, QuizAttempt]) # Added QuizAttempt
+    await connect_to_mongo()
 
 # Registrar rutas de la API (ambas)
 app.include_router(router)


### PR DESCRIPTION
## Summary
- implement `connect_to_mongo` utility under `app/db`
- use `connect_to_mongo` during startup instead of inline logic

## Testing
- `pytest tests/unit -q`
- `pytest -q` *(fails: TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_6851d4c3268c832f9943743d8a284cf6