### PR TITLE
Add comparative metrics to stats endpoint

### DIFF
--- a/app/schemas/stats.py
+++ b/app/schemas/stats.py
@@ -22,6 +22,12 @@ class UserOverallStats(BaseModel):
     average_wpm: Optional[float] = None
     total_quizzes_taken: int
     average_quiz_score: Optional[float] = None # Percentage
+    delta_wpm_vs_previous: Optional[float] = None
+    delta_comprehension_vs_previous: Optional[float] = None
+    delta_reading_time_vs_previous: Optional[float] = None
+    reading_progress_percent: Optional[float] = None
+    wpm_trend: Optional[str] = None  # "up", "down", "stable"
+    comprehension_trend: Optional[str] = None
 
 class PersonalizedFeedback(BaseModel):
     feedback_text: str


### PR DESCRIPTION
## Summary
- extend `UserOverallStats` with delta and trend fields
- compute previous/current period metrics and progress in `StatsService`
- add WPM progress and trend logic

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q mongomock_motor==0.0.21`
- `pip install -q requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c90ad2dbc832f9f42cbbfd73dd714